### PR TITLE
Add guards to skip Disqus and GA scripts when config values are empty

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
 
 </head>
 
-{% if jekyll.environment == 'production' %}
+{% if jekyll.environment == 'production' and site.google_analytics and site.google_analytics != '' %}
 <!-- change your GA id in _config.yml -->
 <script>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -179,7 +179,7 @@ ga('send', 'pageview');
 
 <script src="{{ site.baseurl }}/assets/js/ie10-viewport-bug-workaround.js"></script> 
 
-{% if page.layout == 'post' %}
+{% if page.layout == 'post' and site.disqus and site.disqus != '' %}
 <script id="dsq-count-scr" src="//{{site.disqus}}.disqus.com/count.js"></script>
 {% endif %}
 


### PR DESCRIPTION
Add guards to skip Disqus and GA scripts when config values are empty