### PR TITLE
Make copyright year dynamic via JS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -151,7 +151,7 @@ ga('send', 'pageview');
     <div class="container">
         <div class="row">
             <div class="col-md-6 col-sm-6 text-center text-lg-left">
-                Copyright © {{ site.time | date: "%Y" }} {{ site.name }} 
+                Copyright © <span id="copyright-year">{{ site.time | date: "%Y" }}</span> {{ site.name }} 
             </div>
             <div class="col-md-6 col-sm-6 text-center text-lg-right">    
                 <a target="_blank" href="https://www.wowthemes.net/mediumish-free-jekyll-template/">Mediumish Jekyll Theme</a> by <a target="_blank" href="https://www.wowthemes.net/">WowThemes.net</a>
@@ -162,10 +162,22 @@ ga('send', 'pageview');
 <!-- End Footer
 ================================================== -->
 
-</div> <!-- /.site-content -->
+    </div> <!-- /.site-content -->
 
 <!-- Scripts
 ================================================== -->
+<script>
+(function(){
+  var year = new Date().getFullYear();
+  if (year < 2022) {
+    year = {{ site.time | date: "%Y" }};
+  }
+  var el = document.getElementById("copyright-year");
+  if (el) {
+    el.textContent = year;
+  }
+})();
+</script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
 


### PR DESCRIPTION
This pull request updates the copyright year display in the site footer to ensure it always shows the current year dynamically, rather than relying solely on the site build date. The update adds a JavaScript snippet that sets the year in the footer at runtime.

Footer copyright year improvements:

* Changed the copyright year in the footer to use a `<span id="copyright-year">` for dynamic updates.
* Added a JavaScript snippet that sets the copyright year to the current year using `Date().getFullYear()`, with a fallback to the site build year if needed.