### PR TITLE
Remove unused sort field in archive, exclude compose from site and modernize docker-compose

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,4 +58,4 @@ adsense-data-ad-slot: ""
 # Lazy Images ("enabled" or "disabled")
 lazyimages: "disabled"
 
-exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock]
+exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock, docker-compose.yml]

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -11,7 +11,7 @@ permalink: "/archive.html"
         <h2>Todos los posts</h2>
     </div>
     <div class="row listrecent">
-        {% for post in site.posts | sort: 'last_updated' %}
+        {% for post in site.posts %}
             {% include postbox.html %}
         {% endfor %}
     </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
-jekyll:
-    image: jekyll/jekyll:latest
-    command: jekyll serve --force_polling
+services:
+  jekyll:
+    image: jekyll/jekyll:4
+    command: jekyll serve --force_polling --livereload
     ports:
-        - 4000:4000
+      - 4000:4000
+      - 35729:35729
     volumes:
-        - .:/srv/jekyll
+      - .:/srv/jekyll


### PR DESCRIPTION
This pull request makes several improvements to the Jekyll development workflow and site configuration. The most important changes include updating the `docker-compose.yml` for better local development experience, modifying the posts sorting in the archive layout, and updating the site configuration to exclude the Docker Compose file from the build.

**Development environment improvements:**

* Updated `docker-compose.yml` to use the `jekyll/jekyll:4` image, added the `--livereload` flag to the serve command for automatic browser refresh on file changes, and exposed port `35729` for LiveReload support.

**Site configuration:**

* Added `docker-compose.yml` to the `exclude` list in `_config.yml` to prevent it from being processed by Jekyll during site builds.

**Archive layout changes:**

* Removed sorting by `last_updated` in the posts loop within `_layouts/archive.html`, so posts are now listed in their default order.…