### PR TITLE
Fix YAML snippet syntax and indentation in etcd encryption post

### DIFF
--- a/_posts/2023-06-24-encriptando-etcd-ahora-aesgcm.md
+++ b/_posts/2023-06-24-encriptando-etcd-ahora-aesgcm.md
@@ -163,9 +163,10 @@ oc edit apiserver cluster
 
 Quedando de una forma similar a:
 
-```bash
+```yaml
 apiVersion: config.openshift.io/v1
 kind: APIServer
+metadata:
   name: cluster
 spec:
   audit:
@@ -233,9 +234,10 @@ Es perfectamente posible desactivar el encriptado, al igual que cuando lo activa
 
 Para desactivarlo, es tan sencillo como indicar que el perfil de encriptado será `identity`.
 
-```bash
+```yaml
 apiVersion: config.openshift.io/v1
 kind: APIServer
+metadata:
   name: cluster
 spec:
   audit:


### PR DESCRIPTION
This pull request updates code snippets in the documentation to improve accuracy and clarity by changing the formatting of configuration examples from bash to YAML and adding missing `metadata` sections.
