### PR TITLE
Fix spelling, typos and grammar in control plane machine set post

### DIFF
--- a/_posts/2023-05-25-control-plane-machine-set.md
+++ b/_posts/2023-05-25-control-plane-machine-set.md
@@ -10,7 +10,7 @@ toc: true
 ---
 
 Durante la gestión de máquinas, que luego se convierten en nodos de un clúster de OpenShift, únicamente podíamos controlar aquellas que iban a conformar los nodos de cómputo.<br><br>
-Sin embargo, en el control plane siempre habían sido máquinas muy estáticas y creadas en momento de instalación, y tanto su modificación como su sustitución, siempre había sido un proceso manual, <u>hasta ahora</u>.<br><br>
+Sin embargo, en el control plane siempre habían sido máquinas muy estáticas y creadas en el momento de instalación, y tanto su modificación como su sustitución, siempre había sido un proceso manual, <u>hasta ahora</u>.<br><br>
 Con el `control plane machine set` podemos definir la configuración deseada para las máquinas que forman/formarán el control plane de nuestro clúster de OpenShift.
 
 # Situación actual (OCP 4.13) de esta feature
@@ -56,7 +56,7 @@ Se comenzó con esta feature en OpenShift 4.12, pero ahora mismo, en OpenShift 4
 </table>
 <br>
 
-Hay que tener en cuenta, que el recurso precreado sólo estará disponible en estado `Activo` en los clústeres de nueva instalación.
+Hay que tener en cuenta, que el recurso precreado solo estará disponible en estado `Activo` en los clústeres de nueva instalación.
 
 Tanto para AWS, Azure y GCP, si se trata de clústeres actualizados, el recurso deberá ser activado por un administrador.
 
@@ -64,25 +64,25 @@ Tanto para AWS, Azure y GCP, si se trata de clústeres actualizados, el recurso 
 
 # Descripción general
 
-El `control plane machine set` utiliza un recurso personalizado (Custom Resource), `ControlPlaneMachineSet` con el que  automatizar y gestionar la administración de las máquinas del plano de control dentro de un clúster de OpenShift.
+El `control plane machine set` utiliza un recurso personalizado (Custom Resource), `ControlPlaneMachineSet` con el que automatizar y gestionar la administración de las máquinas del plano de control dentro de un clúster de OpenShift.
 
 Cuando el recurso `ControlPlaneMachineSet` se encuentra configurado y activado, el operador se encargará de cumplir con la cantidad de máquinas definidas para conformar el control plane del clúster con la configuración definida en el propio recurso.
 
-Esto permite el reemplazo automático de máquinas que formarán el control plane si se encuentran en un estado degradado e incluso de implementar los cambios definidos para las propias máquinas del control plane.
+Esto permite el reemplazo automático de máquinas que formarán el control plane si se encuentran en un estado degradado e incluso implementar los cambios definidos para las propias máquinas del control plane.
 
 # Limitaciones 
 
 Hay que tener en cuenta que este recurso está pensado para un mantenimiento y gestión de las máquinas del plano de control, tanto en día 2 como en una operativa recurrente, por lo que tanto la configuración como ajustes deberán realizarse tras la instalación del clúster y no antes o durante una instalación nueva.
 
 - El operador necesita del `Machine API Operator` por lo que no soporta clústeres con las máquinas provisionadas de forma manual.
-- Sólo AWS, Azure, GPC y VMware vSphere está soportado (a versión OCP4.13).
-- Sólo planos de control con tres máquinas se soportan.
+- Solo AWS, Azure, GCP y VMware vSphere está soportado (a versión OCP4.13).
+- Solo planos de control con tres máquinas se soportan.
 - El escalado horizontal de nodos no está soportado usando este operador.
-- El despliegue de máquinas para el control plane en instancias efímeras (spot o similares) o con discos efímeros no está soportado e incrementa el riesgo de perdida de datos y de fallos.
+- El despliegue de máquinas para el control plane en instancias efímeras (spot o similares) o con discos efímeros no está soportado e incrementa el riesgo de pérdida de datos y de fallos.
 
 # Situaciones que nos encontraremos
 
-Las situaciones y la forma de trabajar con el `control plane machine set` va a depender del estado en el que se encuentre el propio recuro de `ControlPlaneMachineSet` en el clúster.
+Las situaciones y la forma de trabajar con el `control plane machine set` va a depender del estado en el que se encuentre el propio recurso de `ControlPlaneMachineSet` en el clúster.
 
 Así, nos podemos encontrar con las siguientes casuísticas.
 


### PR DESCRIPTION
This pull request makes several improvements to the Spanish language and clarity of the documentation for the `control plane machine set` feature in OpenShift. The main focus is on correcting spelling, grammar, and terminology to ensure consistency and readability.

Language and terminology 
Clarity and consistency 
