### PR TITLE
Fix spelling and HTML paragraph closures in about page and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # En Mi Contenedor Funciona
 
-<p>Este blog nace después de muchos años pensando sobre ello como algo para guardar y compartir los problemas encontrados o resueltos.<br> Y también es culpa de la frase más extendida en el mundo IT sobre si los desarrollos funcionan en local pero no en los entornos para desplegar en producción, solo que ahora extendido a los propios contenedores y ya no únicamente al código.</p>
+<p>Este blog nace después de muchos años pensando sobre ello como algo para guardar y compartir los problemas encontrados o resueltos.<br> Y también es culpa de la frase más extendida en el mundo IT sobre si los desarrollos funcionan en local pero no en los entornos para desplegar en producción, solo que ahora extendida a los propios contenedores y ya no únicamente al código.</p>
 
-<p>Aquí habrá notas y pruebas realizadas pero guardadas con algo más de forma, para que no sean simples ficheros de texto almacenados por diferentes discos duros o pendrives y que luego nunca se encuentran cuando se vuelve a necesitar consultar algo que ya investigado o hecho en el pasado y que vuelves a necesitar.</p>
+<p>Aquí habrá notas y pruebas realizadas pero guardadas con algo más de forma, para que no sean simples ficheros de texto almacenados por diferentes discos duros o pendrives y que luego nunca se encuentran cuando se vuelve a consultar algo que ya se ha investigado o hecho en el pasado.</p>
 
 <p>Este blog está alojado en GitHub, lo que significa que permite la colaboración de cualquier persona interesada en contribuir con contenido, <u><em>pull-requests are welcome</em>.</u></p>
 
@@ -10,15 +10,15 @@
 
 <br><p><b>¿Cómo colaborar?</b></p>
 
-<p>Muy sencillo, como con cualquier otro repositorio que puedas encontrar por GitHub.
+<p>Muy sencillo, como con cualquier otro repositorio que puedas encontrar por GitHub.</p>
 
 <br>Este blog está alojado en el siguiente <a href="https://github.com/danifernandezs/enmicontenedorfunciona">repositorio.</a>
 
-<p>Un posible resumen de los pasos serían:</p>
+<p>Un posible resumen de los pasos es:</p>
 <li>Haz un fork del repositorio</li>
 <li>Crea tu rama propia</li>
 <li>Si es la primera vez que colaboras, agrégate como autor en el fichero <em>_config.yml</em></li>
 <li>Crea tu post con el contenido que quieras compartir</li>
-<li>Crea el pull-request para que sea incluído en el blog publicado</li>
+<li>Crea el pull-request para que sea incluido en el blog publicado</li>
 
-<br><p>Si quieres ver algunos ejemplos o posibilidad que permite la plantilla de Jekyll que se usa realmente para este blog, están todos almacenados en <a href="https://www.enmicontenedorfunciona.com/ejemplos-y-opciones">este blogpost.</a>
+<br><p>Si quieres ver algunos ejemplos o posibilidades que permite la plantilla de Jekyll que se usa realmente para este blog, están todos almacenados en <a href="https://www.enmicontenedorfunciona.com/ejemplos-y-opciones">este blogpost.</a></p>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -15,9 +15,9 @@ permalink: /about
 
             <div class="article-post">
 
-                <p>Este blog nace después de muchos años pensando sobre ello como algo para guardar y compartir los problemas encontrados o resueltos.<br> Y también es culpa de la frase más extendida en el mundo IT sobre si los desarrollos funcionan en local pero no en los entornos para desplegar en producción, solo que ahora extendido a los propios contenedores y ya no únicamente al código.</p>
+                <p>Este blog nace después de muchos años pensando sobre ello como algo para guardar y compartir los problemas encontrados o resueltos.<br> Y también es culpa de la frase más extendida en el mundo IT sobre si los desarrollos funcionan en local pero no en los entornos para desplegar en producción, solo que ahora extendida a los propios contenedores y ya no únicamente al código.</p>
 
-                <p>Aquí habrá notas y pruebas realizadas pero guardadas con algo más de forma, para que no sean simples ficheros de texto almacenados por diferentes discos duros o pendrives y que luego nunca se encuentran cuando se vuelve a necesitar consultar algo que ya investigado o hecho en el pasado y que vuelves a necesitar.</p>
+                <p>Aquí habrá notas y pruebas realizadas pero guardadas con algo más de forma, para que no sean simples ficheros de texto almacenados por diferentes discos duros o pendrives y que luego nunca se encuentran cuando se vuelve a consultar algo que ya se ha investigado o hecho en el pasado.</p>
 
                 <p>Este blog está alojado en GitHub, lo que significa que permite la colaboración de cualquier persona interesada en contribuir con contenido, <u><em>pull-requests are welcome</em>.</u></p>
 
@@ -25,15 +25,15 @@ permalink: /about
 
                 <br><p><b>¿Cómo colaborar?</b></p>
 
-                <p>Muy sencillo, como con cualquier otro repositorio que puedas encontrar por GitHub.
+                <p>Muy sencillo, como con cualquier otro repositorio que puedas encontrar por GitHub.</p>
 
                 <br>Este blog está alojado en el siguiente <a href="https://github.com/danifernandezs/enmicontenedorfunciona">repositorio.</a>
 
-                <p>Un posible resumen de los pasos serían:</p>
+                <p>Un posible resumen de los pasos es:</p>
                 <li>Haz un fork del repositorio</li>
                 <li>Crea tu rama propia</li>
                 <li>Si es la primera vez que colaboras, agrégate como autor en el fichero <em>_config.yml</em></li>
                 <li>Crea tu post con el contenido que quieras compartir</li>
-                <li>Crea el pull-request para que sea incluído en el blog publicado</li>
+                <li>Crea el pull-request para que sea incluido en el blog publicado</li>
 
-                <br><p>Si quieres ver algunos ejemplos o posibilidad que permite la plantilla de Jekyll que se usa realmente para este blog, están todos almacenados en <a href="https://www.enmicontenedorfunciona.com/ejemplos-y-opciones">este blogpost.</a>
+                <br><p>Si quieres ver algunos ejemplos o posibilidades que permite la plantilla de Jekyll que se usa realmente para este blog, están todos almacenados en <a href="https://www.enmicontenedorfunciona.com/ejemplos-y-opciones">este blogpost.</a></p>


### PR DESCRIPTION
This pull request focuses on improving the clarity and correctness of the Spanish language used in the documentation and about page. The changes mainly address grammar, spelling, and style issues, resulting in more natural and professional phrasing for contributors and readers.
