### PR TITLE
Remove jekyll-archives config and dependency for GitHub Pages compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :jekyll_plugins do
     gem 'jekyll-sitemap'
     gem 'jekyll-paginate'
     gem 'jekyll-seo-tag'
-    gem 'jekyll-archives'
     gem 'kramdown'
     gem 'rouge'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,6 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-archives (2.1.1)
-      jekyll (>= 2.4)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
     jekyll-paginate (1.1.0)
@@ -69,7 +67,6 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
-  jekyll-archives
   jekyll-feed
   jekyll-paginate
   jekyll-seo-tag

--- a/_config.yml
+++ b/_config.yml
@@ -26,15 +26,6 @@ plugins:
   - jekyll-sitemap
   - jekyll-feed
   - jekyll-seo-tag
-  - jekyll-archives
-
-# Archives
-jekyll-archives:
-  enabled:
-    - categories
-  layout: archive
-  permalinks:
-    category: '/category/:name/'
 
 # Pagination 
 paginate: 6


### PR DESCRIPTION
This pull request removes the `jekyll-archives` plugin from the project. The change simplifies the configuration by eliminating archive-related settings and dependencies.
